### PR TITLE
Replace assert keyword with JUnit5 assertions

### DIFF
--- a/src/test/java/com/diffmin/AppTest.java
+++ b/src/test/java/com/diffmin/AppTest.java
@@ -1,5 +1,8 @@
 package com.diffmin;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import gumtree.spoon.AstComparator;
 import gumtree.spoon.diff.operations.Operation;
 import java.io.File;
@@ -39,11 +42,15 @@ public class AppTest {
         app.applyPatch();
         CtModel patchedCtModel = app.modelToBeModified;
         if (patchedCtModel.getRootPackage().isEmpty()) {
-            assert expectedNewElement == null;
+            assertNull(expectedNewElement, "Patched prev file is not empty");
         }
         else {
             CtElement patchedCtElement = patchedCtModel.getRootPackage().getDirectChildren().get(0);
-            assert expectedNewElement.prettyprint().equals(patchedCtElement.prettyprint());
+            assertEquals(
+                    expectedNewElement.prettyprint(),
+                    patchedCtElement.prettyprint(),
+                    "Prev file was not patched correctly"
+            );
         }
     }
 


### PR DESCRIPTION
Simply using the keyword `assert` thrown an AssertionError which tells nothing about a potential failure. JUnit5 assertions also describe how the derived output is different from the expected one. Reference: https://github.com/SpoonLabs/diffmin/pull/10#discussion_r598469411

I was unsure what type of message is supposed to go in the last parameter of `assertNull` and `assertEquals` because when the tests fail they already show a difference in the derived and expected output so please correct me if I am wrong.