### PR TITLE
Allow one word variable names for MemberNames

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -171,7 +171,7 @@
                      value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="MemberName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

The previous RegEx was forcing one to declare member variables with at least two characters in their name. These changes reduce it to one.