### PR TITLE
Remove warnings thrown by the IDE

### DIFF
--- a/src/main/java/com/diffmin/App.java
+++ b/src/main/java/com/diffmin/App.java
@@ -135,7 +135,7 @@ public class App {
     /**
      * Generate list of patches for each individual operation type - {@link OperationKind}.
      *
-     * @param diff {@link Diff} object
+     * @param diff the diff to generate a patch from
      */
     public void generatePatch(Diff diff) {
         List<Operation> operations = diff.getRootOperations();


### PR DESCRIPTION
The IDE was throwing some warnings related to the code so I decided to remove some of them. Three of them are left now.

1. 'Optional.get()' without 'isPresent()' check 
2. Raw use of parameterized class 'Operation' (can be fixed once https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/155 is resolved)
3. 'OptionalInt.getAsInt()' without 'isPresent()' check
4. In AppTest, Argument 'testDir.listFiles()' might be null

### 1st warning

Is it safe to return an empty string (`""`) if there are no types in a program?

### 3rd warning

I feel it will always return an integer because we are checking for a `srcNodeIndex` in the **newCollectionList**. Is there a way we can ignore this formally?

### 4th warning

I am not sure how to handle this. Is there a way to safely return that there are not tests so the test suite just stops running?