### PR TITLE
Handle case of inserting CtBinaryOperator

### DIFF
--- a/src/main/java/com/diffmin/App.java
+++ b/src/main/java/com/diffmin/App.java
@@ -209,8 +209,8 @@ public class App {
                 ((CtExecutable<?>) inWhichElement)
                         .addParameterAt(where, (CtParameter<?>) toBeInserted);
                 break;
-            case DEFAULT_EXPRESSION:
-                inWhichElement.setValueByRole(CtRole.DEFAULT_EXPRESSION, toBeInserted);
+            default:
+                inWhichElement.setValueByRole(toBeInserted.getRoleInParent(), toBeInserted);
                 break;
         }
     }

--- a/src/main/java/com/diffmin/App.java
+++ b/src/main/java/com/diffmin/App.java
@@ -129,7 +129,7 @@ public class App {
     }
 
     /** Computes the index at which the `insertedNode` has to be inserted. */
-    public int getInsertIndex(CtElement insertedNode) {
+    private int getInsertIndex(CtElement insertedNode) {
         CtElement insertedNodeParent = insertedNode.getParent();
         if (insertedNodeParent.getValueByRole(insertedNode.getRoleInParent()) instanceof List) {
             List<? extends CtElement> newCollectionList = getCollectionElementList(insertedNode);

--- a/src/test/resources/delete+insert/binary_operator/NEW_BinaryOperator.java
+++ b/src/test/resources/delete+insert/binary_operator/NEW_BinaryOperator.java
@@ -1,0 +1,5 @@
+class BinaryOperator {
+    public void func() {
+        int x = 4 + 4;
+    }
+}

--- a/src/test/resources/delete+insert/binary_operator/PREV_BinaryOperator.java
+++ b/src/test/resources/delete+insert/binary_operator/PREV_BinaryOperator.java
@@ -1,0 +1,5 @@
+class BinaryOperator {
+    public void func() {
+        int x = 4;
+    }
+}


### PR DESCRIPTION
The changes add feature generate and apply patches for inserting `CtBinaryOperator`.

@slarse I agree this test case is rather weird because `setValueByRole` gives an intuition of an update operation than an insert one. However, I have some points to justify why this test case is implemented as a combination of `DeleteOperation` and `InsertOperation`.

I will try to explain by taking an analogous case. Consider the following:

**PREV_Klass.java**
```java
class Klass {
    Klass() {
        int a = 1 + 2;
    }
}
```

**NEW_Klass.java**
```java
class Klass {
    public void Klass(int x, int y) {
        int a = 1 + 2;
    }
}
```

It has three root operations.

1. ```sh
    Delete Constructor at Klass:2
	Klass() {
	
	}
    ```
2. ```sh
    Insert Method at Klass:2
	public void Klass(int x, int y) {
	
	}
    ```
3. ```sh
    Move LocalVariable from Klass:3 to Klass:3
    int a = 1 + 2
   ```
   (No idea why this exists. Probably a bug which should reported to gumtree-spoon-ast-diff.)

Instead of the `DeleteOperation` and `InsertOperation` above, there could just be an `UpdateOperation` which updates the `CtTypeMember` from `Klass {}` -> `public void Klass(int x, int y) {}`. But this won't make sense as we would be updating from `CtConstructor` to `CtMethod` changing the type of `CtElement`. Assuming this a correct design, I conclude that the update operations **must be applied on nodes which have the exact same CtElement and it only applies to a single node not its children**.

Extending this logic to the test case in this pull request, we can relate the elements in above case as follows:
1. Klass `CtClass` -> int x `CtLocalVariable`
2. Klass {} `CtConstructor` -> 4 `CtLiteral`
3. public void Klass `CtMethod` -> 4 + 4 `CtBinaryOperator`

For this test case, we can also say that we can just update the `CtLiteral` to `CtBinaryOperator` but I think that is not allowed by the design of `gumtree-spoon-ast-diff`. In other words, an `UpdateOperation` is applied to **one node** and not its children. So it makes sense why there is `DeleteOperation` and `InsertOperation` instead of just one `UpdateOperation`. Moreover, updating a `CtLocalVariable` intuitively means that a variable `int x` is updated to `int y`.