### PR TITLE
chore: Remove unused JUnit4 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit-platform.version}</version>


### PR DESCRIPTION
Dependabot flagged a security alert on JUnit4. But we don't even use JUnit4, it's just dependency bloat, so this PR removes it.