### PR TITLE
Use compilation unit of the model instead of the first type to pretty-print the model

### DIFF
--- a/src/main/java/com/diffmin/Main.java
+++ b/src/main/java/com/diffmin/Main.java
@@ -48,7 +48,7 @@ class Main {
             System.exit(1);
         }
         CtModel patchedCtModel = Main.patchAndGenerateModel(new File(args[0]), new File(args[1]));
-        System.out.println(SpoonUtil.prettyPrintModel(patchedCtModel));
+        System.out.println(SpoonUtil.prettyPrintModelWithSingleCompilationUnit(patchedCtModel));
         System.exit(0);
     }
 }

--- a/src/main/java/com/diffmin/Main.java
+++ b/src/main/java/com/diffmin/Main.java
@@ -48,7 +48,7 @@ class Main {
             System.exit(1);
         }
         CtModel patchedCtModel = Main.patchAndGenerateModel(new File(args[0]), new File(args[1]));
-        System.out.println(SpoonUtil.displayModifiedModel(patchedCtModel));
+        System.out.println(SpoonUtil.prettyPrintModel(patchedCtModel));
         System.exit(0);
     }
 }

--- a/src/main/java/com/diffmin/util/SpoonUtil.java
+++ b/src/main/java/com/diffmin/util/SpoonUtil.java
@@ -5,7 +5,6 @@ import gumtree.spoon.diff.Diff;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
-import java.util.stream.Collectors;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.compiler.SpoonResource;
@@ -79,19 +78,11 @@ public class SpoonUtil {
         List<CtCompilationUnit> compilationUnits =
                 List.copyOf(
                         model.getUnnamedModule().getFactory().CompilationUnit().getMap().values());
-        List<CtCompilationUnit> modelCuCandidates =
-                compilationUnits.stream()
-                        .filter(cu -> !cu.getFile().getName().equals("package-info.java"))
-                        .collect(Collectors.toList());
-        if (modelCuCandidates.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Model does not have a compilation unit after excluding the package-info.java file");
-        }
-        if (modelCuCandidates.size() != 1) {
+        if (compilationUnits.size() != 1) {
             throw new IllegalArgumentException(
                     "There should be exactly one candidate for model's compilation unit");
         }
-        CtCompilationUnit modelCu = modelCuCandidates.get(0);
+        CtCompilationUnit modelCu = compilationUnits.get(0);
         // Note: Must explicitly create our configured pretty printer, as spoon-9.0.0 has that
         // CompilationUnit.prettyprint() always uses the auto-import pretty-printer, and not
         // our custom configured one.

--- a/src/main/java/com/diffmin/util/SpoonUtil.java
+++ b/src/main/java/com/diffmin/util/SpoonUtil.java
@@ -74,13 +74,20 @@ public class SpoonUtil {
         return launcher.buildModel();
     }
 
-    public static String prettyPrintModel(CtModel model) {
+    /**
+     * Pretty-prints the model using the single compilation unit it has.
+     *
+     * @param model model to be pretty printed
+     * @return patched program
+     */
+    public static String prettyPrintModelWithSingleCompilationUnit(CtModel model) {
         List<CtCompilationUnit> compilationUnits =
                 List.copyOf(
                         model.getUnnamedModule().getFactory().CompilationUnit().getMap().values());
         if (compilationUnits.size() != 1) {
             throw new IllegalArgumentException(
-                    "There should be exactly one candidate for model's compilation unit");
+                    "Model should have exactly 1 compilation unit, but has - "
+                            + compilationUnits.size());
         }
         CtCompilationUnit modelCu = compilationUnits.get(0);
         // Note: Must explicitly create our configured pretty printer, as spoon-9.0.0 has that

--- a/src/test/java/com/diffmin/StructureTest.java
+++ b/src/test/java/com/diffmin/StructureTest.java
@@ -62,7 +62,7 @@ class StructureTest {
                             .getFactory()
                             .CompilationUnit()
                             .getOrCreate(retrievedFirstType);
-            String patchedProgram = SpoonUtil.displayModifiedModel(patchedCtModel);
+            String patchedProgram = SpoonUtil.prettyPrintModel(patchedCtModel);
             assertEquals(cu.prettyprint(), patchedProgram, "Prev file was not patched correctly");
         }
     }

--- a/src/test/java/com/diffmin/StructureTest.java
+++ b/src/test/java/com/diffmin/StructureTest.java
@@ -62,7 +62,8 @@ class StructureTest {
                             .getFactory()
                             .CompilationUnit()
                             .getOrCreate(retrievedFirstType);
-            String patchedProgram = SpoonUtil.prettyPrintModel(patchedCtModel);
+            String patchedProgram =
+                    SpoonUtil.prettyPrintModelWithSingleCompilationUnit(patchedCtModel);
             assertEquals(cu.prettyprint(), patchedProgram, "Prev file was not patched correctly");
         }
     }


### PR DESCRIPTION
Fixes #72 

