### PR TITLE
Make insertion of type parameter more generic

### DIFF
--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -66,7 +66,7 @@ public class PatchApplication {
                 ((CtClass<?>) inWhichElement).addTypeMemberAt(where, (CtTypeMember) toBeInserted);
                 break;
             case TYPE_PARAMETER:
-                ((CtClass<?>) inWhichElement)
+                ((CtFormalTypeDeclarer) inWhichElement)
                         .addFormalCtTypeParameterAt(where, (CtTypeParameter) toBeInserted);
                 break;
             case PARAMETER:

--- a/src/main/java/com/diffmin/patch/PatchGeneration.java
+++ b/src/main/java/com/diffmin/patch/PatchGeneration.java
@@ -135,7 +135,7 @@ public class PatchGeneration {
                             case TYPE_MEMBER:
                                 return ((CtClass<?>) element.getParent()).getTypeMembers();
                             case TYPE_PARAMETER:
-                                return ((CtClass<?>) element.getParent())
+                                return ((CtFormalTypeDeclarer) element.getParent())
                                         .getFormalCtTypeParameters();
                             case PARAMETER:
                                 return ((CtExecutable<?>) element.getParent()).getParameters();

--- a/src/test/resources/insert/type-parameter/NEW_TypeParameter.java
+++ b/src/test/resources/insert/type-parameter/NEW_TypeParameter.java
@@ -1,1 +1,3 @@
-class TypeParameter<A, B> { }
+class TypeParameter<A, B> {
+    public <K, V> void doNothing() { }
+}

--- a/src/test/resources/insert/type-parameter/PREV_TypeParameter.java
+++ b/src/test/resources/insert/type-parameter/PREV_TypeParameter.java
@@ -1,1 +1,3 @@
-class TypeParameter<B> { }
+class TypeParameter<B> {
+    public <V> void doNothing() { }
+}

--- a/src/test/resources/insert/type-parameter/new_revision_paths
+++ b/src/test/resources/insert/type-parameter/new_revision_paths
@@ -1,1 +1,2 @@
 #containedType[name=TypeParameter]#typeParameter[name=A]
+#containedType[name=TypeParameter]#method[signature=doNothing()]#typeParameter[name=K]


### PR DESCRIPTION
I noticed a minor issue while performing some experiments on methods with annotations. `PatchGeneration` threw a type-cast exception while processing the test data.