### PR TITLE
Make insertion of methods valid for `CtType`

### DIFF
--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -63,7 +63,7 @@ public class PatchApplication {
                         .addArgumentAt(where, (CtExpression<?>) toBeInserted);
                 break;
             case TYPE_MEMBER:
-                ((CtClass<?>) inWhichElement).addTypeMemberAt(where, (CtTypeMember) toBeInserted);
+                ((CtType<?>) inWhichElement).addTypeMemberAt(where, (CtTypeMember) toBeInserted);
                 break;
             case TYPE_PARAMETER:
                 ((CtFormalTypeDeclarer) inWhichElement)

--- a/src/main/java/com/diffmin/patch/PatchGeneration.java
+++ b/src/main/java/com/diffmin/patch/PatchGeneration.java
@@ -134,7 +134,7 @@ public class PatchGeneration {
                                 return ((CtAbstractInvocation<?>) element.getParent())
                                         .getArguments();
                             case TYPE_MEMBER:
-                                return ((CtClass<?>) element.getParent()).getTypeMembers();
+                                return ((CtType<?>) element.getParent()).getTypeMembers();
                             case TYPE_PARAMETER:
                                 return ((CtFormalTypeDeclarer) element.getParent())
                                         .getFormalCtTypeParameters();

--- a/src/test/resources/insert/method/NEW_Shape.java
+++ b/src/test/resources/insert/method/NEW_Shape.java
@@ -1,0 +1,21 @@
+public interface Shape {
+    String getName();
+    int getPerimeter();
+    int getArea();
+}
+
+class Square implements Shape {
+    private int side;
+
+    public String getName() {
+        return "Square";
+    }
+
+    public int getPerimeter() {
+        return side*4;
+    }
+
+    public int getArea() {
+        return side*side;
+    }
+}

--- a/src/test/resources/insert/method/PREV_Shape.java
+++ b/src/test/resources/insert/method/PREV_Shape.java
@@ -1,0 +1,16 @@
+public interface Shape {
+    String getName();
+    int getArea();
+}
+
+class Square implements Shape {
+    private int side;
+
+    public String getName() {
+        return "Square";
+    }
+
+    public int getArea() {
+        return side*side;
+    }
+}

--- a/src/test/resources/insert/method/new_revision_paths
+++ b/src/test/resources/insert/method/new_revision_paths
@@ -1,0 +1,2 @@
+#containedType[name=Shape]#method[signature=getPerimeter()]
+#containedType[name=Square]#method[signature=getPerimeter()]


### PR DESCRIPTION
Typecasting the parent to `CtClass` allowed insertion of methods in classes only. Modifying cast to `CtType` will incorporate insertion of methods in interfaces too.