### PR TITLE
Add functionality to insert modifiers in `CtTypeMember`s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>fr.inria.gforge.spoon.labs</groupId>
       <artifactId>gumtree-spoon-ast-diff</artifactId>
-      <version>1.30</version>
+      <version>1.34</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -2,6 +2,8 @@ package com.diffmin.patch;
 
 import com.diffmin.util.Pair;
 import com.diffmin.util.SpoonUtil;
+import gumtree.spoon.builder.CtVirtualElement;
+import gumtree.spoon.builder.CtWrapper;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -89,6 +91,16 @@ public class PatchApplication {
                 List<CtType<?>> types = new ArrayList<>(inWhichCompilationUnit.getDeclaredTypes());
                 types.add(where, (CtType<?>) toBeInserted);
                 inWhichCompilationUnit.setDeclaredTypes(types);
+                break;
+            case MODIFIER:
+                if (toBeInserted instanceof CtVirtualElement) {
+                    //                    ((CtTypeMember)
+                    // inWhichElement).setModifiers(((CtVirtualElement)
+                    // toBeInserted).getChildren());
+                } else {
+                    ((CtTypeMember) inWhichElement)
+                            .addModifier((ModifierKind) ((CtWrapper<?>) toBeInserted).getValue());
+                }
                 break;
             default:
                 inWhichElement.setValueByRole(toBeInserted.getRoleInParent(), toBeInserted);

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -94,9 +94,11 @@ public class PatchApplication {
                 break;
             case MODIFIER:
                 if (toBeInserted instanceof CtVirtualElement) {
-                    //                    ((CtTypeMember)
-                    // inWhichElement).setModifiers(((CtVirtualElement)
-                    // toBeInserted).getChildren());
+                    Set<ModifierKind> newModifiers = new HashSet<>();
+                    for (Object modifierKind : ((CtVirtualElement) toBeInserted).getChildren()) {
+                        newModifiers.add((ModifierKind) modifierKind);
+                    }
+                    ((CtTypeMember) inWhichElement).setModifiers(newModifiers);
                 } else {
                     ((CtTypeMember) inWhichElement)
                             .addModifier((ModifierKind) ((CtWrapper<?>) toBeInserted).getValue());

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -98,9 +98,9 @@ public class PatchApplication {
                     for (Object modifierKind : ((CtVirtualElement) toBeInserted).getChildren()) {
                         newModifiers.add((ModifierKind) modifierKind);
                     }
-                    ((CtTypeMember) inWhichElement).setModifiers(newModifiers);
+                    ((CtModifiable) inWhichElement).setModifiers(newModifiers);
                 } else {
-                    ((CtTypeMember) inWhichElement)
+                    ((CtModifiable) inWhichElement)
                             .addModifier((ModifierKind) ((CtWrapper<?>) toBeInserted).getValue());
                 }
                 break;

--- a/src/test/resources/insert/final/NEW_FinalModifier.java
+++ b/src/test/resources/insert/final/NEW_FinalModifier.java
@@ -1,7 +1,0 @@
-final class FinalModifier {
-    public final int x;
-    protected final int y;
-    private final int z;
-
-    public final void doNothing() { }
-}

--- a/src/test/resources/insert/final/NEW_FinalModifier.java
+++ b/src/test/resources/insert/final/NEW_FinalModifier.java
@@ -1,5 +1,7 @@
-class FinalModifier {
+final class FinalModifier {
     public final int x;
     protected final int y;
     private final int z;
+
+    public final void doNothing() { }
 }

--- a/src/test/resources/insert/final/NEW_FinalModifier.java
+++ b/src/test/resources/insert/final/NEW_FinalModifier.java
@@ -1,0 +1,5 @@
+class FinalModifier {
+    public final int x;
+    protected final int y;
+    private final int z;
+}

--- a/src/test/resources/insert/final/PREV_FinalModifier.java
+++ b/src/test/resources/insert/final/PREV_FinalModifier.java
@@ -1,0 +1,5 @@
+class FinalModifier {
+    public int x;
+    protected int y;
+    private int z;
+}

--- a/src/test/resources/insert/final/PREV_FinalModifier.java
+++ b/src/test/resources/insert/final/PREV_FinalModifier.java
@@ -2,4 +2,6 @@ class FinalModifier {
     public int x;
     protected int y;
     private int z;
+
+    public void doNothing() { }
 }

--- a/src/test/resources/insert/modifier/NEW_Modifier.java
+++ b/src/test/resources/insert/modifier/NEW_Modifier.java
@@ -1,0 +1,7 @@
+public abstract class Modifier {
+    public static int x;
+    protected static int y;
+    private static int z;
+
+    public final void doNothing() { }
+}

--- a/src/test/resources/insert/modifier/NEW_Modifier.java
+++ b/src/test/resources/insert/modifier/NEW_Modifier.java
@@ -3,5 +3,7 @@ public abstract class Modifier {
     protected static int y;
     private static int z;
 
-    public final void doNothing() { }
+    public final void doNothing() {
+        final int x = 10;
+    }
 }

--- a/src/test/resources/insert/modifier/PREV_Modifier.java
+++ b/src/test/resources/insert/modifier/PREV_Modifier.java
@@ -1,7 +1,7 @@
-class FinalModifier {
+class Modifier {
     public int x;
     protected int y;
-    private int z;
+    static int z;
 
     public void doNothing() { }
 }

--- a/src/test/resources/insert/modifier/PREV_Modifier.java
+++ b/src/test/resources/insert/modifier/PREV_Modifier.java
@@ -3,5 +3,7 @@ class Modifier {
     protected int y;
     static int z;
 
-    public void doNothing() { }
+    public void doNothing() {
+        int x = 10;
+    }
 }


### PR DESCRIPTION
The changes insert modifiers in `CtTypeMembers`. I am not sure how to test for element origin because they are not _real_ nodes.

To be merged after:
- [x] https://github.com/SpoonLabs/gumtree-spoon-ast-diff/pull/161 is merged
- [x] https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/162 is resolved