### PR TITLE
Add functionality for inserting case

### DIFF
--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -7,10 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
-import spoon.reflect.code.CtAbstractInvocation;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtStatementList;
+import spoon.reflect.code.*;
 import spoon.reflect.declaration.*;
 import spoon.reflect.reference.CtTypeReference;
 
@@ -47,6 +44,7 @@ public class PatchApplication {
     }
 
     /** Apply the insert patch. */
+    @SuppressWarnings("unchecked")
     private static void performInsertion(
             ImmutableTriple<Integer, CtElement, CtElement> insertPatch) {
         int where = insertPatch.left;
@@ -89,6 +87,16 @@ public class PatchApplication {
                 List<CtType<?>> types = new ArrayList<>(inWhichCompilationUnit.getDeclaredTypes());
                 types.add(where, (CtType<?>) toBeInserted);
                 inWhichCompilationUnit.setDeclaredTypes(types);
+                break;
+            case CASE:
+                List<CtCase<? super Object>> cases =
+                        ((CtAbstractSwitch<Object>) inWhichElement).getCases();
+                if (cases.isEmpty()) {
+                    ((CtAbstractSwitch<Object>) inWhichElement)
+                            .addCase((CtCase<? super Object>) toBeInserted);
+                } else {
+                    cases.add(where, (CtCase<? super Object>) toBeInserted);
+                }
                 break;
             default:
                 inWhichElement.setValueByRole(toBeInserted.getRoleInParent(), toBeInserted);

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -91,14 +91,7 @@ public class PatchApplication {
                 inWhichCompilationUnit.setDeclaredTypes(types);
                 break;
             case CASE:
-                List<CtCase<? super Object>> cases =
-                        ((CtAbstractSwitch<Object>) inWhichElement).getCases();
-                if (cases.isEmpty()) {
-                    ((CtAbstractSwitch<Object>) inWhichElement)
-                            .addCase((CtCase<? super Object>) toBeInserted);
-                } else {
-                    cases.add(where, (CtCase<? super Object>) toBeInserted);
-                }
+                ((CtAbstractSwitch<Object>) inWhichElement).addCaseAt(where, (CtCase<? super Object>) toBeInserted);
                 break;
             case MODIFIER:
                 if (toBeInserted instanceof CtVirtualElement) {

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -91,7 +91,8 @@ public class PatchApplication {
                 inWhichCompilationUnit.setDeclaredTypes(types);
                 break;
             case CASE:
-                ((CtAbstractSwitch<Object>) inWhichElement).addCaseAt(where, (CtCase<? super Object>) toBeInserted);
+                ((CtAbstractSwitch<Object>) inWhichElement)
+                        .addCaseAt(where, (CtCase<? super Object>) toBeInserted);
                 break;
             case MODIFIER:
                 if (toBeInserted instanceof CtVirtualElement) {

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import spoon.reflect.code.CtAbstractInvocation;
+import spoon.reflect.code.CtAbstractSwitch;
+import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
@@ -59,6 +61,7 @@ public class PatchApplication {
     }
 
     /** Apply the insert patch. */
+    @SuppressWarnings("unchecked")
     private static void performInsertion(
             ImmutableTriple<Integer, CtElement, CtElement> insertPatch) {
         int where = insertPatch.left;
@@ -113,6 +116,10 @@ public class PatchApplication {
                     ((CtModifiable) inWhichElement)
                             .addModifier((ModifierKind) ((CtWrapper<?>) toBeInserted).getValue());
                 }
+                break;
+            case CASE:
+                ((CtAbstractSwitch<Object>) inWhichElement)
+                        .addCaseAt(where, (CtCase<? super Object>) toBeInserted);
                 break;
             default:
                 inWhichElement.setValueByRole(toBeInserted.getRoleInParent(), toBeInserted);

--- a/src/main/java/com/diffmin/patch/PatchGeneration.java
+++ b/src/main/java/com/diffmin/patch/PatchGeneration.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import spoon.reflect.code.CtAbstractInvocation;
+import spoon.reflect.code.CtAbstractSwitch;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.*;
 import spoon.reflect.path.CtRole;
@@ -143,6 +144,8 @@ public class PatchGeneration {
                             case CONTAINED_TYPE:
                                 CtCompilationUnit cu = SpoonUtil.getTheOnlyCompilationUnit(element);
                                 return cu.getDeclaredTypes();
+                            case CASE:
+                                return ((CtAbstractSwitch<?>) element.getParent()).getCases();
                             default:
                                 throw new UnsupportedOperationException(
                                         "Unsupported role: " + element.getRoleInParent());

--- a/src/test/resources/insert/case/NEW_Case.java
+++ b/src/test/resources/insert/case/NEW_Case.java
@@ -1,0 +1,16 @@
+class Case {
+    public void func() {
+        int x = 0;
+        switch (x % 2) {
+            case 1:
+                System.out.println("Odd");
+                break;
+            case 0:
+                System.out.println("Even");
+                break;
+            default:
+                System.out.println("Fraction");
+                break;
+        }
+    }
+}

--- a/src/test/resources/insert/case/NEW_Case.java
+++ b/src/test/resources/insert/case/NEW_Case.java
@@ -12,5 +12,11 @@ class Case {
                 System.out.println("Fraction");
                 break;
         }
+
+        switch (x % 3) {
+            default:
+                System.out.println("Checking for divisibility by 3");
+                break;
+        }
     }
 }

--- a/src/test/resources/insert/case/NEW_Case.java
+++ b/src/test/resources/insert/case/NEW_Case.java
@@ -18,5 +18,11 @@ class Case {
                 System.out.println("Checking for divisibility by 3");
                 break;
         }
+
+        int y = switch (x) {
+            case 1 -> 10;
+            case 2 -> 20;
+            default -> 30;
+        };
     }
 }

--- a/src/test/resources/insert/case/PREV_Case.java
+++ b/src/test/resources/insert/case/PREV_Case.java
@@ -9,5 +9,7 @@ class Case {
                 System.out.println("Fraction");
                 break;
         }
+
+        switch (x % 3) { }
     }
 }

--- a/src/test/resources/insert/case/PREV_Case.java
+++ b/src/test/resources/insert/case/PREV_Case.java
@@ -1,0 +1,13 @@
+class Case {
+    public void func() {
+        int x = 0;
+        switch (x % 2) {
+            case 1:
+                System.out.println("Odd");
+                break;
+            default:
+                System.out.println("Fraction");
+                break;
+        }
+    }
+}

--- a/src/test/resources/insert/case/PREV_Case.java
+++ b/src/test/resources/insert/case/PREV_Case.java
@@ -11,5 +11,10 @@ class Case {
         }
 
         switch (x % 3) { }
+
+        int y = switch (x) {
+            case 1 -> 10;
+            default -> 30;
+        };
     }
 }

--- a/src/test/resources/insert/case/new_revision_paths
+++ b/src/test/resources/insert/case/new_revision_paths
@@ -1,2 +1,3 @@
 #containedType[name=Case]#method[signature=func()]#body#statement[index=1]#case[index=1]
 #containedType[name=Case]#method[signature=func()]#body#statement[index=2]#case[index=0]
+#containedType[name=Case]#method[signature=func()]#body#statement[index=3]#defaultExpression#case[index=1]

--- a/src/test/resources/insert/case/new_revision_paths
+++ b/src/test/resources/insert/case/new_revision_paths
@@ -1,0 +1,1 @@
+#containedType[name=Case]#method[signature=func()]#body#statement[index=1]#case[index=1]

--- a/src/test/resources/insert/case/new_revision_paths
+++ b/src/test/resources/insert/case/new_revision_paths
@@ -1,1 +1,2 @@
 #containedType[name=Case]#method[signature=func()]#body#statement[index=1]#case[index=1]
+#containedType[name=Case]#method[signature=func()]#body#statement[index=2]#case[index=0]


### PR DESCRIPTION
Changes add functionality to insert a case in `CtAbstractSwitch` which includes `CtSwitch` and `CtSwitchExpression`. However, the latter has not been tested because this language feature came about in Java 12 (standardised in v14) and we currently compile to Java SE 11.

To be merged after:
- [x] https://github.com/INRIA/spoon/issues/3884#issuecomment-869130820 is addressed.
- [x] https://github.com/INRIA/spoon/pull/4015 is merged. 
- [x] https://github.com/SpoonLabs/diffmin/issues/82 is resolved.