### PR TITLE
Add checkstyle configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,9 @@ jobs:
       with:
         java-version: 11
     - name: Style check
-      run: 'mvn spotless:check'
+      run: |
+        mvn spotless:check
+        mvn checkstyle:check
     - name: Run test phase
       run: mvn test
     - name: Upload coverage report to Codecov

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,10 +41,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Style check
-      run: |
-        mvn spotless:check
-        mvn checkstyle:check
+    - name: Style check using spotless
+      run: 'mvn spotless:check'
+    - name: Style check using checkstyle
+      run: 'mvn checkstyle:check'
     - name: Run test phase
       run: mvn test
     - name: Upload coverage report to Codecov

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="ConstantName"/>
+
+        <!-- Validate that first sentence is not empty and first sentence is not missing -->
+        <module name="SummaryJavadocCheck"/>
+        <module name="InvalidJavadocPosition"/>
+
+        <module name="JavadocType">
+            <property name="scope" value="package"/>
+        </module>
+        <module name="MissingJavadocType">
+            <property name="scope" value="package"/>
+        </module>
+
+        <module name="JavadocMethod">
+            <property name="accessModifiers" value="public, package"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="package"/>
+            <property name="excludeScope" value="protected"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+        </module>
+
+        <module name="AvoidStarImport"/>
+
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyCatchBlock"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,21 @@
           <version>2.5.2</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>3.1.2</version>
+          <configuration>
+            <configLocation>checkstyle.xml</configLocation>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.44</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.10.3</version>

--- a/src/main/java/com/diffmin/Main.java
+++ b/src/main/java/com/diffmin/Main.java
@@ -9,7 +9,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import spoon.reflect.CtModel;
 
-/** Main execution of generating and applying patch */
+/** Main execution of generating and applying patch. */
 class Main {
 
     /**

--- a/src/main/java/com/diffmin/patch/PatchApplication.java
+++ b/src/main/java/com/diffmin/patch/PatchApplication.java
@@ -13,7 +13,17 @@ import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
-import spoon.reflect.declaration.*;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtModifiable;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtTypeReference;
 
 /** Class for applying patches. */

--- a/src/main/java/com/diffmin/patch/PatchGeneration.java
+++ b/src/main/java/com/diffmin/patch/PatchGeneration.java
@@ -16,7 +16,11 @@ import java.util.stream.IntStream;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtStatementList;
-import spoon.reflect.declaration.*;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.path.CtRole;
 
 /** Class for generating patches. */

--- a/src/main/java/com/diffmin/util/SpoonUtil.java
+++ b/src/main/java/com/diffmin/util/SpoonUtil.java
@@ -10,7 +10,10 @@ import spoon.compiler.Environment;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.CtModel;
-import spoon.reflect.declaration.*;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.PrettyPrinter;
 


### PR DESCRIPTION
Fixes #85 

Added additional styles which spotless (using AOSP) didn't check for.
- Format of constant variables
- Javadoc format
- Avoid star import
- Avoid nested blocks
- Empty catch block

We can add more of such [checks](https://checkstyle.sourceforge.io/checks.html) if we need them.