### PR TITLE
chore: Update Spoon and gumtree-spoon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,13 @@
     <dependency>
       <groupId>fr.inria.gforge.spoon.labs</groupId>
       <artifactId>gumtree-spoon-ast-diff</artifactId>
-      <version>1.46</version>
+      <version>1.49</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>fr.inria.gforge.spoon</groupId>
       <artifactId>spoon-core</artifactId>
-      <version>9.1.0</version>
+      <version>10.0.1-beta-2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/diffmin/SpoonMapping.java
+++ b/src/main/java/com/diffmin/SpoonMapping.java
@@ -3,7 +3,8 @@ package com.diffmin;
 import com.diffmin.util.Pair;
 import com.github.gumtreediff.matchers.Mapping;
 import com.github.gumtreediff.matchers.MappingStore;
-import com.github.gumtreediff.tree.ITree;
+import com.github.gumtreediff.tree.Tree;
+import com.github.gumtreediff.tree.TypeSet;
 import gumtree.spoon.builder.SpoonGumTreeBuilder;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -49,11 +50,10 @@ public class SpoonMapping {
                     throw new IllegalStateException();
                 }
                 if (m.first.getType()
-                        != -1) { // -1 is the type given to root node in SpoonGumTreeBuilder
+                        != TypeSet.type("root")) { // -1 is the type given to root node in
+                    // SpoonGumTreeBuilder
                     throw new IllegalStateException(
-                            "non-root node "
-                                    + m.first.toShortString()
-                                    + " had no mapped Spoon object");
+                            "non-root node " + m.first + " had no mapped Spoon object");
                 }
             } else {
                 mapping.put(spoonSrc, spoonDst);
@@ -144,7 +144,7 @@ public class SpoonMapping {
         dstToSrc.put(dst, src);
     }
 
-    private static CtElement getSpoonNode(ITree gumtreeNode) {
+    private static CtElement getSpoonNode(Tree gumtreeNode) {
         return (CtElement) gumtreeNode.getMetadata(SpoonGumTreeBuilder.SPOON_OBJECT);
     }
 


### PR DESCRIPTION
The behaviour of gumtree-spoon has become more fine-grained and that is why test cases are failing. Example:

```diff
class BinaryOperator {
    public void func() {
-       int x = 4;
+       int x = 4 + 4;
    }
}
```
Earlier, this had two operations - `Delete Literal [4]` and `Insert BinaryOperator [4+4]`. Now the operations have become - `Insert BinaryOperator [+4]` and `Move Literal [4]`. So while generating a patch for `4` (move operation), the program is unable to find the mapping of the literal. 